### PR TITLE
replaced space by _ in name for clean filepath w/ bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "notifier JS",
+  "name": "notifier_JS",
   "description": "Javascript plugin to display bealtiful and personalized notifications",
   "version": "1.0.0",
   "main": "dist/js/notifier.min.js",


### PR DESCRIPTION
Bower uses the package's name to create the directory in which reside the files. If the file is included as is, there will be a space in the file path, which might produce errors.

I've just changed the name so that there's no space anymore.